### PR TITLE
Dev/overware tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ flight inventory modify map -c example-switch
 Set some layout parameters:
 
 ```
-flight inventory modify other layout=t-l-v example-switch
-flight inventory modify other width=24 example-switch
-flight inventory modify other height=2 example-switch
+flight inventory modify other map_layout=t-l-v example-switch
+flight inventory modify other map_width=24 example-switch
+flight inventory modify other map_height=2 example-switch
 ```
 
 Render an SVG representation of `example-switch`:

--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ provide a small number of configuration values:
  * `width`: number of ports wide
  * `height`: number of ports high
  * `layout`: port numbering method, one of:
-   * `t-l-v`: top-left is port 1, numbering proceeds vertically
-   * `t-l-h`: top-left is port 1, numbering proceeds horizontally
-   * `t-r-v`: top-right is port 1, numbering proceeds vertically (in reverse)
-   * `t-r-h`: top-right is port 1, numbering proceeds horizontally (in reverse)
-   * as above, but for `b-l-v`, `b-l-h` etc. where port 1 is at the bottom
+   * `t-l-v`: top-left is port 1, numbering proceeds vertically (down-then-right)
+   * `t-l-h`: top-left is port 1, numbering proceeds horizontally (right-then-down)
+   * `b-l-v`: bottom-left is port 1, numbering proceeds vertically (up-then-right)
+   * `b-l-h`: bottom-left is port 1, numbering proceeds horizontally (right-then-up)
+   * as above, but for `t-r-v`, `t-l-h` etc. where port 1 is on the right
 
 The diagram plugin has an additional number of configuration values
 which can be tweaked by the creation of a new template:

--- a/etc/templates.yml
+++ b/etc/templates.yml
@@ -1,6 +1,8 @@
 diagram-markdown:
-  default: diagram-switch.md.erb
+  default: server.md.erb
+  server: server.md.erb
   switch: diagram-switch.md.erb
 diagram-svg:
-  default: diagram-switch.svg.erb
+  default: server.md.erb
+  server: server.md.erb
   switch: diagram-switch.svg.erb

--- a/examples/create-examples.rb
+++ b/examples/create-examples.rb
@@ -46,19 +46,19 @@ class Template
     @template = File.read(File.join(TEMPLATE_DIR, "#{name}.erb"))
   end
 
-  def render(node_data)
-    env = render_env(node_data)
-    env.instance_variable_set(:@node_data, node_data)
+  def render(asset_data)
+    env = render_env(asset_data)
+    env.instance_variable_set(:@asset_data, asset_data)
     ctx = env.instance_eval { binding }
     ERB.new(@template, nil, '-').result(ctx)
   end
 
-  def render_env(node_data)
+  def render_env(asset_data)
     @render_env ||=
       begin
         Module.new do
           class << self
-            attr_reader :node_data
+            attr_reader :asset_data
           end
         end.tap do |m|
           Dir[File.join(HELPER_DIR,'*.rb')].each do |file|
@@ -121,7 +121,7 @@ markdown_tpl = Template.new('switch.md')
 svg_tpl = Template.new('switch.svg')
 
 LAYOUTS.each do |l|
-  node_data = NodeData.new(
+  asset_data = NodeData.new(
     {
       map: send("create_#{l[:map_type]}_map", l[:width], l[:height]),
       width: l[:width].to_s,
@@ -130,8 +130,8 @@ LAYOUTS.each do |l|
     }
   )
   title = "#{l[:width]}x#{l[:height]}-#{l[:layout]}-#{l[:map_type]}"
-  svg_out = svg_tpl.render(node_data)
+  svg_out = svg_tpl.render(asset_data)
   File.open("#{title}.svg",'w') { |f| f.puts(svg_out) }
-  md_out = markdown_tpl.render(node_data)
+  md_out = markdown_tpl.render(asset_data)
   File.open("#{title}.md",'w') { |f| f.puts(md_out) }
 end

--- a/helpers/diagrams.rb
+++ b/helpers/diagrams.rb
@@ -29,7 +29,7 @@ require 'base64'
 require 'diagrams/renderer'
 
 def render_switch(opts)
-  map = @node_data.mutable.map&.to_h
+  map = @asset_data.mutable.map&.to_h
   Diagrams::Renderer.render(opts, map)
 end
 

--- a/lib/diagrams/renderer.rb
+++ b/lib/diagrams/renderer.rb
@@ -40,7 +40,7 @@ module Diagrams
     end
 
     def initialize(opts, map)
-      truncate_at = opts.fetch(:truncate_at, 9)
+      truncate_at = opts.fetch(:truncate_at, 15)
       @style = create_style(opts)
       @names = create_name_array(map, truncate_at)
       @layout = create_layout(opts)

--- a/templates/diagram-switch.md.erb
+++ b/templates/diagram-switch.md.erb
@@ -27,16 +27,16 @@
 # https://github.com/alces-software/flight-inventory-diagrams
 #===============================================================================
 -%>
-# <%= @node_data.name %>
+# <%= @asset_data.name %>
 
 <img src="data:image/svg+xml;base64,<%= render_switch_base64(
-  width: @node_data.mutable.map_width,
-  height: @node_data.mutable.map_height,
-  layout: @node_data.mutable.map_layout,
+  width: @asset_data.mutable.map_width,
+  height: @asset_data.mutable.map_height,
+  layout: @asset_data.mutable.map_layout,
 )%>">
 
 |Port|Note|
 |----|----|
-<% (@node_data.mutable.map || {}).to_h.each do |k,v| -%>
+<% (@asset_data.mutable.map || {}).to_h.each do |k,v| -%>
 |<%= k %>|<%= v %>|
 <% end %>

--- a/templates/diagram-switch.md.erb
+++ b/templates/diagram-switch.md.erb
@@ -30,9 +30,9 @@
 # <%= @node_data.name %>
 
 <img src="data:image/svg+xml;base64,<%= render_switch_base64(
-  width: @node_data.mutable.width,
-  height: @node_data.mutable.height,
-  layout: @node_data.mutable.layout,
+  width: @node_data.mutable.map_width,
+  height: @node_data.mutable.map_height,
+  layout: @node_data.mutable.map_layout,
 )%>">
 
 |Port|Note|

--- a/templates/diagram-switch.svg.erb
+++ b/templates/diagram-switch.svg.erb
@@ -29,8 +29,8 @@
 -%>
 <%=
   render_switch(
-    width: @node_data.mutable.map_width,
-    height: @node_data.mutable.map_height,
-    layout: @node_data.mutable.map_layout,
+    width: @asset_data.mutable.map_width,
+    height: @asset_data.mutable.map_height,
+    layout: @asset_data.mutable.map_layout,
   )
 %>

--- a/templates/diagram-switch.svg.erb
+++ b/templates/diagram-switch.svg.erb
@@ -29,8 +29,8 @@
 -%>
 <%=
   render_switch(
-    width: @node_data.mutable.width,
-    height: @node_data.mutable.height,
-    layout: @node_data.mutable.layout,
+    width: @node_data.mutable.map_width,
+    height: @node_data.mutable.map_height,
+    layout: @node_data.mutable.map_layout,
   )
 %>


### PR DESCRIPTION
Some tweaks I've made to get this in line with requirements & to integrate with overware

- Change the target fields to be prefixed with `map_`  - this has also been changed in inventoryware
- Altered the suggested layouts to be top-left and bottom-left rather than top-left and top-right to follow the requirements (this ended up only being a change to the README here, more of a change in inventoryware proper)
- Expanded the default max truncation length to prevent diagrams from being consistently squished (cfd-ms-01001 is 12 chars, for example)
- Update the templates.yml file to point to the standard server template unless explicitly rendering a switch - is this alright by you @mjtko ?

---
EDIT - Also changed node_data to asset_data in parallel with a change to flight-inventory